### PR TITLE
Improved speed.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,8 @@
-resolver: nightly-2017-01-28
+resolver: nightly-2017-01-30
 packages:
-    - '.'
-
+  - '.'
 flags: {}
 extra-package-dbs: []
 system-ghc: false
+ghc-options:
+  "*": -Wall -O2 -threaded -rtsopts -with-rtsopts=-N


### PR DESCRIPTION
There were a few minor issues that had a dramatic impact:
* Although you were using `RPU` (parallel) representation it was only using a single core, since executable wasn't compiled with `-threaded`. I added a few more ghc flags.
* Due to the way you were using `foldl'` it was creating a big image for each tile, despite that fusion was of some help, there was a huge amount of wasteful computation. Just as you said in lehins/hip#7, at each iteration within fold, because of superimpose, it was traversing the whole new image. So a simpler solution is to create a list of list of zoomed tiles and recombine them into the big image.
* Historically in image processing Rows and Columns are used (comes from matrices, I guess), which is an opposite order to Height and Width. I switched those up for you where appropriate.

Now as a bonus feature I can tell you that `hip` is also capable of creating animated GIFs ;) So you don't need to use imagemagick for that. Look into function `writeImageExact`. Here is an example:

     λ> writeImageExact [GIF] [GIFsLooping LoopingForever] "img.gif" $ zip (repeat 50) imgs