### PR TITLE
Fixed gif saving, introduced lower boud for hip

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,11 +20,8 @@ import           Graphics.Image  ( scale
                                  , VS (..)
                                  , Border (..)
                                  , Bilinear (..)
-                                 -- , ImageFormat (..)
-                                 -- , SaveOption (..)
-                                 , GifDelay
                                  )
-import Graphics.Image.IO.Formats 
+import           Graphics.Image.IO.Formats
 import           System.Random   (randomRIO)
 import           Control.Monad   (replicateM)
 import           Options.Generic ( getRecord
@@ -101,17 +98,16 @@ zoomImage opts image = do
     return $ applyActionsOnRegions actionsRegions image
 
 
-writeGif :: Array arr RGB Double
-         => Options
-         -> Image arr RGB Double
-         -> IO ()
+writeGif :: (Array VS cs e,
+             Writable [(GifDelay, Image VS cs e)] GIFA, Array arr' cs e) =>
+            Options -> Image arr' cs e -> IO ()
 writeGif opts image = do
     imgs <- replicateM 50 (zoomImage opts image)
     let delays = repeat 20 :: [GifDelay]
     writeImageExact GIFA
                     [GIFALooping LoopingForever]
                     (outImage opts)
-                    (zip delays images)
+                    (zip delays $ map (exchange VS) imgs)
 
 
 writeNormal :: Array arr RGB Double

--- a/rezoomer.cabal
+++ b/rezoomer.cabal
@@ -26,7 +26,7 @@ executable rezoomer
   ghc-options: -Wall
   build-depends:
       base >= 4.7 && < 5
-    , hip
+    , hip >= 1.5.2.0
     , random
     , optparse-generic
   default-language: Haskell2010


### PR DESCRIPTION
Also address your comment on: lehins/hip/pull/8

Your implementation of GIF writing looks good, needed to bring back `exchange VS` though, since `VS` representation is the only one that can be written directly without change of representation, which `writeImageExact` does not do.

Importing `LoopingForever` can be done easily by `import Graphics.Image (GifLooping(LoopingForever))` - it's a re-export of JuicyPixel's type, but explicit import of `GIFALooping` constructor is tricky business, and I might be wrong, but apparently it is not supported, since it is a data constructor for an associated type family. Here are a few references for this:
* https://downloads.haskell.org/~ghc/7.10.3/docs/html/users_guide/type-families.html
* http://stackoverflow.com/questions/34501501/importing-the-data-constructor-of-an-associated-data-type
* https://ghc.haskell.org/trac/ghc/ticket/10027